### PR TITLE
my_memdump: can mark serial addresses as symbolic

### DIFF
--- a/panda/plugins/config.panda
+++ b/panda/plugins/config.panda
@@ -23,5 +23,5 @@ get_insn_trace
 get_asid
 bufmon
 my_memdump
-map_instr
+#map_instr
 get_basic_blocks

--- a/panda/plugins/config.panda
+++ b/panda/plugins/config.panda
@@ -24,3 +24,4 @@ get_asid
 bufmon
 my_memdump
 map_instr
+get_basic_blocks

--- a/panda/plugins/get_basic_blocks/Makefile
+++ b/panda/plugins/get_basic_blocks/Makefile
@@ -1,0 +1,10 @@
+# Don't forget to add your plugin to config.panda!
+
+# If you need custom CFLAGS or LIBS, set them up here
+# LIBS+=
+# CFLAGS+=-save-temps
+
+PLUGIN_OBJFILES=$(PLUGIN_OBJ_DIR)/$(PLUGIN_NAME).o
+
+# Plugin dynamic library. At ../panda_$(PLUGIN_NAME).so
+$(PLUGIN_TARGET_DIR)/panda_$(PLUGIN_NAME).so: $(PLUGIN_OBJFILES)

--- a/panda/plugins/get_basic_blocks/get_basic_blocks.cpp
+++ b/panda/plugins/get_basic_blocks/get_basic_blocks.cpp
@@ -1,0 +1,63 @@
+#define __STDC_FORMAT_MACROS
+
+#include "panda/plugin.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <ctype.h>
+#include <math.h>
+#include <map>
+#include <list>
+#include <algorithm>
+#include <sys/mman.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <vector>
+#include <iostream>
+#include <sstream>
+
+extern "C" {
+
+bool init_plugin(void *);
+void uninit_plugin(void *);
+int before_block_exec(CPUState *env, TranslationBlock *tb);
+}
+
+int basic_blocks_bin;
+
+int before_block_exec(CPUState *env, TranslationBlock *tb) {
+    printf("pc: %d\n", tb->pc);
+
+    if (write(serial_basic_blocks_bin, &tb->pc, 4) != 4){
+        fprintf(stderr, "Couldn't write pc\n");
+        perror("write");
+    }
+
+    return 0;
+}
+
+bool init_plugin(void *self) {
+    printf("Initializing plugin get_basic_blocks\n");
+
+    basic_blocks_bin = open("basic_blocks.bin", O_CREAT | O_TRUNC | O_WRONLY, S_IRUSR | S_IWUSR);
+    if(basic_blocks_bin == -1) {
+        printf("Cannor open/create basic_blocks.bin:\n");
+        perror("fopen");
+        return false;
+    }
+
+    panda_cb pcb;
+    panda_enable_memcb();
+    pcb.before_block_exec = before_block_exec;
+    panda_register_callback(self, PANDA_CB_BEFORE_BLOCK_EXEC, pcb);
+
+    return true;
+}
+
+void uninit_plugin(void *self) {
+    printf("Uninitializing plugin\n");
+
+    close(basic_blocks_bin);
+
+    panda_disable_memcb();
+}

--- a/panda/plugins/get_basic_blocks/get_basic_blocks.cpp
+++ b/panda/plugins/get_basic_blocks/get_basic_blocks.cpp
@@ -28,7 +28,7 @@ int basic_blocks_bin;
 int before_block_exec(CPUState *env, TranslationBlock *tb) {
     printf("pc: %d\n", tb->pc);
 
-    if (write(serial_basic_blocks_bin, &tb->pc, 4) != 4){
+    if (write(basic_blocks_bin, &tb->pc, 4) != 4){
         fprintf(stderr, "Couldn't write pc\n");
         perror("write");
     }


### PR DESCRIPTION
Addresses mapped to serial devices can be marked as symbolic by passing relevant arguments to the my_memdump plugin as follows `my_memdump:make_symbolic,addrs=0xff000|0xff018`.